### PR TITLE
Develop

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,7 @@ module.exports = {
     "no-caller": 2, // disallow use of arguments.caller or arguments.callee
     "no-div-regex": 2, // disallow division operators explicitly at beginning of regular expression (off by default)
     "no-else-return": 2, // disallow else after a return in an if (off by default)
-    "no-labels": 2, // disallow use of labels for anything other then loops and switches
+    "no-labels": 2, // disallow use of labels for anything other then loops, switches and labeled statements
     "no-eq-null": 2, // disallow comparisons to null without a type-checking operator (off by default)
     "no-eval": 2, // disallow use of eval()
     "no-extend-native": 2, // disallow adding to native types
@@ -93,7 +93,6 @@ module.exports = {
     "no-floating-decimal": 2, // disallow the use of leading or trailing decimal points in numeric literals (off by default)
     "no-implied-eval": 2, // disallow use of eval()-like methods
     "no-iterator": 2, // disallow usage of __iterator__ property
-    "no-labels": 2, // disallow use of labeled statements
     "no-lone-blocks": 2, // disallow unnecessary nested blocks
     "no-loop-func": 2, // disallow creation of functions within loops
     "no-multi-spaces": 2, // disallow use of multiple spaces

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ language: node_js
 node_js:
   - "6"
   - "7"
-
-before_script:
-  - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run lint",
-    "lint": "eslint ."
+    "lint": "eslint . ./bin/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes:

* Add ESLint ignore file explicitly to ignore `node_modules` which is default by ESLint.
* Remove duplicate "no-labels" rule from .eslint configure and merge the comments.
* Fix the skipping of non JS extension (JS files with no extensions located under `./bin`) in ESLint execution.
* Remove the unnecessary grunt-cli installation command in Travis configure. As I don't see Grunt or Gulp is being used in entire codebase. Please let me know in case I am missing something here.
