### PR TITLE
avoid an array with an undefined value

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -17,7 +17,16 @@ module.exports = function instance(input, done) {
   var defineSuite = function (config) {
     var nemo;
     var requireFromConfig = profileConf.mocha.require;
-    var modulesToRequire = Array.isArray(requireFromConfig) ? requireFromConfig : [requireFromConfig];
+    var modulesToRequire = [];
+
+    // if an array was already declared, use it
+    if (requireFromConfig && Array.isArray(requireFromConfig)) {
+      modulesToRequire = requireFromConfig;
+
+    // else if it was a single module declared, format to array
+    } else if (requireFromConfig && typeof requireFromConfig === 'string') {
+      modulesToRequire = [requireFromConfig];
+    }
 
     modulesToRequire.forEach(function (module) {
       try {


### PR DESCRIPTION
If the user does not add `"require"` in the mocha config, then we had been making `modulesToRequire` an array with one value that was `undefined`, which caused the `require` in the loop to bomb. This PR properly calculates `modulesToRequire`, which will be `[]` as a default.