### PR TITLE
append profile name to report filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.2
+
+- append profile name to report filename
+
 ## v1.0.1
 
 - fix file name appending

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You should have seen two Firefox and two Chrome browser instances open and execu
 
 ## Reporters
 
-Recommended reporters are `mochawesome` or `mocha-jenkins-reporter`. `nemo-runner` will automatically append grep/test file names to report names when using either of these.
+Recommended reporters are `mochawesome` or `mocha-jenkins-reporter`. `nemo-runner` will automatically append profile, grep, and test file names to report names when using any of these.
 
 ## How it works
 

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -29,6 +29,7 @@ let profile = function profile(cb) {
       tags: {profile: profil},
       conf: conf
     };
+    util.append(instance.conf, filenamify(profil));
     this.instances.push(instance);
   }.bind(this));
   cb(null, this);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-runner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wrapper to run nemo/mocha suites",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,8 @@
   "author": "grawk <mattedelman@gmail.com>",
   "contributors": [
     "grawk <mattedelman@gmail.com>",
-    "Kurt Weiberth <kurt.weiberth@gmail.com>"
+    "Kurt Weiberth <kurt.weiberth@gmail.com>",
+    "Ethan Godt <ethan@ethangodt.com>"
   ],
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
**Info:**
Append the profile name to the report filename just as is done with
`grep`s. This prevents machawesome from saving over other reports from
other profiles on the same overall execution.

i.e. `nemo-runner -P chrome,safari -G @tag@` would produce:

**before:**
```
[mochawesome] Report JSON saved to
{path}/nemo-report_@tag@.json

[mochawesome] Report HTML saved to
{path}/nemo-report_@tag@.html
```

**after:**
```
[mochawesome] Report JSON saved to
{path}/nemo-report_chrome_@tag@.json

[mochawesome] Report HTML saved to
{path}/nemo-report_chrome_@tag@.html

[mochawesome] Report JSON saved to
{path}/nemo-report_safari_@tag@.json

[mochawesome] Report HTML saved to
{path}/nemo-report_safari_@tag@.html
```