### PR TITLE
prevent all unnecessary mocha.run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.1
+
+- prevent mocha from running against 0 matches in "parallel": "file" mode
+
 ## v1.1.0
 
 - append profile name to report filename

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -14,6 +14,20 @@ module.exports = function instance(input, done) {
   var driverConfig;
   var runner;
 
+  var exitInstance = function (failures, summary) {
+    // only attach this listener if we aren't running in parallel
+    if (!done && process) {
+      process.on('exit', function () {
+        // exit with non-zero status if there were failures
+        process.exit(failures);
+      });
+    }
+    // attempted to run with no matching suites/tests
+    if (!anyTests && done) {
+      done(summary);
+    }
+  };
+
   var defineSuite = function (config) {
     var nemo;
     var requireFromConfig = profileConf.mocha.require;
@@ -45,18 +59,20 @@ module.exports = function instance(input, done) {
     // calculate driver configuration
     driverConfig = profileConf.driver;
     config.set('driver', Object.assign({}, config.get('driver'), driverConfig));
+
+    if (profileConf.parallel === 'file') {
+      // if we're running parallel by file, make sure we really need to run()
+      mocha.loadFiles();
+      const throwawayRunner = new Mocha.Runner(mocha.suite);
+      const matchingTests = throwawayRunner.grep(mocha.options.grep).total;
+      if (!matchingTests) {
+        // don't run the suite, just exit the process
+        return exitInstance();
+      }
+    }
+
     runner = mocha.run(function (failures) {
-      // only attach this listener if we aren't running in parallel
-      if (!done && process) {
-        process.on('exit', function () {
-          // exit with non-zero status if there were failures
-          process.exit(failures);
-        });
-      }
-      // attempted to run with no matching suites/tests
-      if (!anyTests && done) {
-        done(result);
-      }
+      exitInstance(failures, result);
     });
     // runner.on('start', function (Arg) {
     //         // never called. filed https://github.com/mochajs/mocha/issues/2753

--- a/lib/util.js
+++ b/lib/util.js
@@ -40,7 +40,9 @@ module.exports.kickoff = function kickoff() {
       // The handlers come here: (none of them is mandatory)
       .on('message', function (summary) {
         log('Thread complete', summary);
-        results.push(summary);
+        if (summary) {
+          results.push(summary);
+        }
         thread.kill();
       })
       .on('error', function (er) {


### PR DESCRIPTION
When things are run with `"parallel": "file"`, instances of mocha are
created and run that do not need to be (all files from the `baseDir`
are sent as an instance before a `grep` is run on them).

This PR checks to see if it's "parallel by file" and then that there are
actually grep matches on that file before `mocha.run()` is invoked.

addresses #8 