### PR TITLE
support maxConcurrent tasks in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+
+- allow setting concurrency limit in config with `maxConcurrent` for parallel testing
+
 ## v1.1.1
 
 - prevent mocha from running against 0 matches in "parallel": "file" mode

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ You should have seen two Firefox and two Chrome browser instances open and execu
 
 `base.env` any environment variables you want in the test process
 
+`base.maxConcurrent` a number which represents the max limit of concurrent suites nemo-runner will execute in parallel - if not provided there is no limit
+
 ## Reporters
 
 Recommended reporters are `mochawesome` or `mocha-jenkins-reporter`. `nemo-runner` will automatically append profile, grep, and test file names to report names when using any of these.

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@
 var spawn = require('threads').spawn;
 var instance = require('../lib/instance');
 var debug = require('debug');
+var parallelLimit = require('async/parallelLimit');
 var log = debug('nemo-runner:log');
 var error = debug('nemo-runner:error');
 
@@ -24,6 +25,9 @@ module.exports.kickoff = function kickoff() {
   var results = [];
   var complete = 0;
   var iconfig;
+  var tasks;
+  var maxConcurrent;
+
   if (this.instances.length === 1) {
     iconfig = this.instances[0];
     log('single kickoff with instance %O', iconfig.tags);
@@ -32,10 +36,11 @@ module.exports.kickoff = function kickoff() {
     return instance({basedir: this.program.baseDirectory, profile: iconfig});
   }
   // parallel use case
-  this.instances.forEach(function (iconf) {
-    var thread = spawn(instance, {env: Object.assign({}, process.env, iconf.conf.env || {})});
-    log('multi kickoff with instance %O', iconf.tags);
-    thread
+  tasks = this.instances.map(function (iconf) {
+    return function (done) {
+      var thread = spawn(instance, {env: Object.assign({}, process.env, iconf.conf.env || {})});
+      log('multi kickoff with instance %O', iconf.tags);
+      thread
       .send({basedir: this.program.baseDirectory, profile: iconf})
       // The handlers come here: (none of them is mandatory)
       .on('message', function (summary) {
@@ -67,6 +72,11 @@ module.exports.kickoff = function kickoff() {
           console.log(results);
           /* eslint-enable */
         }
+        done();
       }.bind(this));
+    }.bind(this);
   }.bind(this));
+
+  maxConcurrent = this.config.get('profiles:base:maxConcurrent') || Infinity;
+  parallelLimit(tasks, maxConcurrent);
 };


### PR DESCRIPTION
Adds logic to `util.kickoff()` that limits the number of parallel tasks by
the value provided at `config.base.maxConcurrent` in the config. If no
limit, run it unbounded with `Infinity`.

Will update `CHANGELOG`, etc. if you want to merge.

closes #9 