### PR TITLE
add thread.kill to error case

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -52,6 +52,7 @@ module.exports.kickoff = function kickoff() {
       })
       .on('error', function (er) {
         error(er);
+        thread.kill();
       })
       .on('exit', function () {
         var totals;


### PR DESCRIPTION
Occasionally processes would fail, and be restarted indefinitely preventing `nemo-runner` from exiting for hours.

Adding this kill forces the process to `exit` where it also invokes `done()` so `async.parallelLimit` knows it can continue.