### PR TITLE
fix logic determining final suite end. add mocha test context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## v1.3.1 
+## UNRELEASED
+
+- modify driver kill logic (again) to exit nemo when the `root` mocha Suite ends
+- add current mocha test's context to the `nemo.mocha` property
+
+## v1.3.1
 
 - modify driver kill logic to count total suites (fixes nested suites)
 - add nested suites to tests

--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ a number which represents the max limit of concurrent suites nemo-runner will ex
 
 Recommended reporters are `mochawesome` or `mocha-jenkins-reporter`. `nemo-runner` will automatically append profile, grep, and test file names to report names when using any of these.
 
-## How it works
+## Adding Nemo into the mocha context and vice versa
 
 nemo-runner injects a `nemo` instance into the Mocha context (for it, before, after, etc functions) which can be accessed by
 `this.nemo` within the test suites.
 
+nemo-runner also adds the current test's context to `nemo.mocha`. That can be useful if you want to access or modify the test's context from within a nemo plugin.
 ### Parallel functionality
 
 nemo-runner will execute in parallel `-P (profile)` x `-G (grep)` mocha instances. The example above uses "browser" as the

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -89,7 +89,7 @@ let pfile = function pfile(cb) {
         var justFile = file.split(this.program.baseDirectory)[1];
         justFile = filenamify(justFile);
         // remove file ext
-        justFile = (justFile.endsWith('.js')) ? justFile.substr(0,justFile.length - 3) : justFile;
+        justFile = (justFile.endsWith('.js')) ? justFile.substr(0, justFile.length - 3) : justFile;
         log('flow:pfile, file %s', justFile);
         _instance = merge({}, instance);
         _instance.conf.tests = [file];

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -15,22 +15,6 @@ module.exports = function instance(input, done) {
   var driverConfig;
   var runner;
 
-  var getSuitesQty = function getSuitesQty(suite) {
-    var s = suite;
-    var qty = 0;
-    log('getSuitesQty start');
-    while (!s.root) {
-      s = s.parent;
-    }
-    function findSuites(_s) {
-      _s.suites.forEach(function (__s) {
-        findSuites(__s);
-      });
-      return (qty += 1);
-    }
-    return findSuites(s);
-  };
-
   var exitInstance = function (failures, summary) {
     // only attach this listener if we aren't running in parallel
     if (!done && process) {
@@ -49,8 +33,6 @@ module.exports = function instance(input, done) {
     var nemo;
     var requireFromConfig = profileConf.mocha.require;
     var modulesToRequire = [];
-    var suitesQty;
-    var doneSuites = 0;
 
     // if an array was already declared, use it
     if (requireFromConfig && Array.isArray(requireFromConfig)) {
@@ -99,6 +81,7 @@ module.exports = function instance(input, done) {
     // });
     runner.on('test', function (Test) {
       Test.ctx.nemo = nemo;
+      nemo.mocha = Test.ctx;
     });
     // runner.on('test end', function (Test) {
     //         // not using this currently
@@ -121,8 +104,7 @@ module.exports = function instance(input, done) {
 
 
     runner.on('suite', function (Suite) {
-      suitesQty = suitesQty || getSuitesQty(Suite);
-      log('suite event, suitesQty %s, suite', suitesQty, Suite.title);
+      log('suite event, suite %s, root: %s', Suite.title, Suite.root);
       anyTests = true;
       if (nemo && nemo.driver) {
         return;
@@ -142,9 +124,8 @@ module.exports = function instance(input, done) {
       Suite._beforeAll.unshift(Suite._beforeAll.pop());
     });
     runner.on('suite end', function (Evt) {
-      log('suite end called for %s', Evt.title);
-      doneSuites += 1;
-      if (doneSuites === suitesQty && nemo && nemo.driver) {
+      log('suite end called for %s which is root: %s', Evt.title, Evt.root);
+      if (Evt.root && nemo && nemo.driver) {
         nemo.driver.quit()
           .then(function () {
             log('Suite is ended. Quit driver and call done');

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,10 @@
 describe('@suite1@suite2@suite3@suite4@', function () {
     it('may fail a few times1', function () {
         let nemo = this.nemo;
+        //verify nemo.mocha property
+        if (!nemo.mocha === this) {
+            return Promise.reject(new Error('didnt find mocha context at nemo.mocha'));
+        }
         return nemo.driver.get(nemo.data.baseUrl)
             .then(function () {
                 return nemo.driver.sleep(500);
@@ -12,6 +16,10 @@ describe('@suite1@suite2@suite3@suite4@', function () {
     describe('@inner@', function () {
         it('may fail a few times2', function () {
             let nemo = this.nemo;
+            //verify nemo.mocha property
+            if (!nemo.mocha === this) {
+                return Promise.reject(new Error('didnt find mocha context at nemo.mocha'));
+            }
             return nemo.driver.get(nemo.data.baseUrl)
               .then(function () {
                   return nemo.driver.sleep(500);


### PR DESCRIPTION
BUG: The current "all suites ended" logic is overly complex and sometimes fails. Waiting for the "root" suite to finish is the simpler and more effective approach.

FEATURE: add the mocha test context to `nemo.mocha` such that it can be used in plugins to access/modify the test's context. Should be useful in plugins.